### PR TITLE
add the possibility to select an xml config from application.properties

### DIFF
--- a/UsageControlFramework/src/main/java/it/cnr/iit/usagecontrolframework/property/Properties.java
+++ b/UsageControlFramework/src/main/java/it/cnr/iit/usagecontrolframework/property/Properties.java
@@ -2,14 +2,14 @@
  * Copyright 2018 IIT-CNR
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License.  You may obtain a copy
- * of the License at
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
  ******************************************************************************/
@@ -84,7 +84,7 @@ public final class Properties extends AbstractProperties {
 		String xml = "";
 		try {
 			InputStream stream = Properties.class.getClassLoader()
-			    .getResourceAsStream(CONFIGURATION);
+			    .getResourceAsStream(getXMLConfigurationFileName());
 			BufferedReader buffer = new BufferedReader(new InputStreamReader(stream));
 			String line = "";
 			
@@ -113,6 +113,20 @@ public final class Properties extends AbstractProperties {
 	public int getThread(String string) {
 		// TODO Auto-generated method stub
 		return 0;
+	}
+	
+	private String getXMLConfigurationFileName() {
+		java.util.Properties prop = new java.util.Properties();
+		String propFileName = "application.properties";
+		InputStream is = getClass().getClassLoader()
+		    .getResourceAsStream(propFileName);
+		
+		try {
+			prop.load(is);
+			return prop.getProperty("ucs-config-file");
+		} catch (Exception e) {
+		}
+		return CONFIGURATION;
 	}
 	
 }

--- a/UsageControlFramework/src/main/resources/application.properties
+++ b/UsageControlFramework/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+ucs-config-file=conf_local.xml


### PR DESCRIPTION
This patch makes possible to select a different UCS xml configuration file selecting it through the application.properties file otherwise the default name will be used.